### PR TITLE
Fixed link to github repo

### DIFF
--- a/src/components/Footer/SocialLinks.jsx
+++ b/src/components/Footer/SocialLinks.jsx
@@ -5,7 +5,7 @@ import { strings } from '../Localization/Localization';
 export default () => {
   const links = [{
     tooltip: strings.app_github,
-    path: `//github.com/odota/underlords-ui`,
+    path: `//github.com/odota/underlords-web`,
     icon: <IconGithub />,
   }];
 


### PR DESCRIPTION
Link in footer went to `//github.com/odota/underlords-ui`, I changed it to `//github.com/odota/underlords-web` which I assume is the repo it's supposed to go to.